### PR TITLE
Fix/force newline after description

### DIFF
--- a/Sources/SwiftFormatRules/DeclSyntaxProtocol+Comments.swift
+++ b/Sources/SwiftFormatRules/DeclSyntaxProtocol+Comments.swift
@@ -62,7 +62,7 @@ extension DeclSyntaxProtocol {
       case .newlines(let n), .carriageReturns(let n), .carriageReturnLineFeeds(let n):
         // Only allow for 1 newline between doc line comments, but allow for newlines between the
         // doc comment and the declaration.
-        guard !hasSeenFirstLineComment else { break gatherComments }
+        guard n == 1 || !hasSeenFirstLineComment else { break gatherComments }
       case .spaces, .tabs:
         // Skip all spaces/tabs. They're irrelevant here.
         break

--- a/Sources/swift-format/VersionOptions.swift
+++ b/Sources/swift-format/VersionOptions.swift
@@ -20,7 +20,7 @@ struct VersionOptions: ParsableArguments {
   func validate() throws {
     if version {
       // TODO: Automate updates to this somehow.
-      print("508.0.0")
+      print("508.0.1")
       throw ExitCode.success
     }
   }

--- a/Tests/SwiftFormatPrettyPrintTests/ArrayDeclTests.swift
+++ b/Tests/SwiftFormatPrettyPrintTests/ArrayDeclTests.swift
@@ -11,15 +11,15 @@ final class ArrayDeclTests: PrettyPrintTestCase {
       let a = [
         // Comment
       ]
-      let a = [1, 2, 3,]
+      let a = [1, 2, 3]
       let a: [Bool] = [false, true, true, false]
       let a = [11111111, 2222222, 33333333, 4444444]
       let a: [String] = ["One", "Two", "Three", "Four"]
       let a: [String] = ["One", "Two", "Three", "Four", "Five", "Six", "Seven"]
-      let a: [String] = ["One", "Two", "Three", "Four", "Five", "Six", "Seven",]
+      let a: [String] = ["One", "Two", "Three", "Four", "Five", "Six", "Seven"]
       let a: [String] = [
         "One", "Two", "Three", "Four", "Five",
-        "Six", "Seven", "Eight",
+        "Six", "Seven", "Eight"
       ]
       let a = [11111111, 2222222, 33333333, 444444]
       """
@@ -34,22 +34,22 @@ final class ArrayDeclTests: PrettyPrintTestCase {
       let a = [1, 2, 3]
       let a: [Bool] = [false, true, true, false]
       let a = [
-        11111111, 2222222, 33333333, 4444444,
+        11111111, 2222222, 33333333, 4444444
       ]
       let a: [String] = [
-        "One", "Two", "Three", "Four",
-      ]
-      let a: [String] = [
-        "One", "Two", "Three", "Four", "Five",
-        "Six", "Seven",
+        "One", "Two", "Three", "Four"
       ]
       let a: [String] = [
         "One", "Two", "Three", "Four", "Five",
-        "Six", "Seven",
+        "Six", "Seven"
       ]
       let a: [String] = [
         "One", "Two", "Three", "Four", "Five",
-        "Six", "Seven", "Eight",
+        "Six", "Seven"
+      ]
+      let a: [String] = [
+        "One", "Two", "Three", "Four", "Five",
+        "Six", "Seven", "Eight"
       ]
 
       """
@@ -58,7 +58,7 @@ final class ArrayDeclTests: PrettyPrintTestCase {
       // always added to last element and that 1 character causes the newlines inside of the array.
       + """
       let a = [
-        11111111, 2222222, 33333333, 444444,
+        11111111, 2222222, 33333333, 444444
       ]
 
       """
@@ -157,9 +157,9 @@ final class ArrayDeclTests: PrettyPrintTestCase {
     let input =
       """
       let a = [
-        "String",
+        "String"
       ]
-      let a = [1, 2, 3,]
+      let a = [1, 2, 3]
       let a: [String] = [
         "One", "Two", "Three", "Four", "Five",
         "Six", "Seven", "Eight"
@@ -168,23 +168,6 @@ final class ArrayDeclTests: PrettyPrintTestCase {
 
     assertPrettyPrintEqual(
       input: input, expected: input + "\n", linelength: 45, whitespaceOnly: true)
-  }
-
-  func testTrailingCommaDiagnostics() {
-    let input =
-      """
-      let a = [1, 2, 3,]
-      let a: [String] = [
-        "One", "Two", "Three", "Four", "Five",
-        "Six", "Seven", "Eight"
-      ]
-      """
-
-    assertPrettyPrintEqual(
-      input: input, expected: input + "\n", linelength: 45, whitespaceOnly: true)
-
-    XCTAssertDiagnosed(.removeTrailingComma, line: 1, column: 17)
-    XCTAssertDiagnosed(.addTrailingComma, line: 4, column: 26)
   }
 
   func testGroupsTrailingComma() {
@@ -192,7 +175,7 @@ final class ArrayDeclTests: PrettyPrintTestCase {
       """
       let a = [
         condition ? firstOption : secondOption,
-        bar(),
+        bar()
       ]
       """
 
@@ -202,7 +185,7 @@ final class ArrayDeclTests: PrettyPrintTestCase {
         condition
           ? firstOption
           : secondOption,
-        bar(),
+        bar()
       ]
 
       """
@@ -228,13 +211,13 @@ final class ArrayDeclTests: PrettyPrintTestCase {
         ("abc", "def", "xyz"),
         (
           "this ", "string", "is long"
-        ),
+        )
       ]
       let a = [
         ("abc", "def", "xyz"),
         (
           "this ", "string", "is long"
-        ),
+        )
       ]
       let a = [
         ("this ", "string", "is long")
@@ -244,11 +227,11 @@ final class ArrayDeclTests: PrettyPrintTestCase {
       ]
       let a = [
         "this ", "string",
-        "is longer",
+        "is longer"
       ]
       let a = [
         ("this", "str"),
-        ("is", "lng"),
+        ("is", "lng")
       ]
 
       """
@@ -257,7 +240,7 @@ final class ArrayDeclTests: PrettyPrintTestCase {
       // always added to last element and that 1 character causes the newlines inside of the array.
       + """
       a = [
-        ("az", "by"), ("cf", "de"),
+        ("az", "by"), ("cf", "de")
       ]
 
       """

--- a/Tests/SwiftFormatPrettyPrintTests/CommentTests.swift
+++ b/Tests/SwiftFormatPrettyPrintTests/CommentTests.swift
@@ -220,30 +220,30 @@ final class CommentTests: PrettyPrintTestCase {
       // Array comment
       let a = [
         456,  // small comment
-        789,
+        789
       ]
 
       // Dictionary comment
       let b = [
         "abc": 456,  // small comment
-        "def": 789,
+        "def": 789
       ]
 
       // Trailing comment
       let c = [
-        123, 456,  // small comment
+        123, 456  // small comment
       ]
 
       /* Array comment */
       let a = [
         456, /* small comment */
-        789,
+        789
       ]
 
       /* Dictionary comment */
       let b = [
         "abc": 456, /* small comment */
-        "def": 789,
+        "def": 789
       ]
 
       """

--- a/Tests/SwiftFormatPrettyPrintTests/DictionaryDeclTests.swift
+++ b/Tests/SwiftFormatPrettyPrintTests/DictionaryDeclTests.swift
@@ -14,15 +14,15 @@ final class DictionaryDeclTests: PrettyPrintTestCase {
       :
       // Comment B
       ]
-      let a = [1: "a", 2: "b", 3: "c",]
+      let a = [1: "a", 2: "b", 3: "c"]
       let a: [Int: String] = [1: "a", 2: "b", 3: "c"]
       let a = [10000: "abc", 20000: "def", 30000: "ghij"]
       let a: [Int: String] = [1: "a", 2: "b", 3: "c", 4: "d"]
       let a: [Int: String] = [1: "a", 2: "b", 3: "c", 4: "d", 5: "e", 6: "f", 7: "g"]
-      let a: [Int: String] = [1: "a", 2: "b", 3: "c", 4: "d", 5: "e", 6: "f", 7: "g",]
+      let a: [Int: String] = [1: "a", 2: "b", 3: "c", 4: "d", 5: "e", 6: "f", 7: "g"]
       let a: [Int: String] = [
         1: "a", 2: "b", 3: "c", 4: "d", 5: "e", 6: "f",
-        7: "g", 8: "i",
+        7: "g", 8: "i"
       ]
       let a = [10000: "abc", 20000: "def", 30000: "ghi"]
       """
@@ -39,22 +39,22 @@ final class DictionaryDeclTests: PrettyPrintTestCase {
       let a = [1: "a", 2: "b", 3: "c"]
       let a: [Int: String] = [1: "a", 2: "b", 3: "c"]
       let a = [
-        10000: "abc", 20000: "def", 30000: "ghij",
+        10000: "abc", 20000: "def", 30000: "ghij"
       ]
       let a: [Int: String] = [
-        1: "a", 2: "b", 3: "c", 4: "d",
-      ]
-      let a: [Int: String] = [
-        1: "a", 2: "b", 3: "c", 4: "d", 5: "e", 6: "f",
-        7: "g",
+        1: "a", 2: "b", 3: "c", 4: "d"
       ]
       let a: [Int: String] = [
         1: "a", 2: "b", 3: "c", 4: "d", 5: "e", 6: "f",
-        7: "g",
+        7: "g"
       ]
       let a: [Int: String] = [
         1: "a", 2: "b", 3: "c", 4: "d", 5: "e", 6: "f",
-        7: "g", 8: "i",
+        7: "g"
+      ]
+      let a: [Int: String] = [
+        1: "a", 2: "b", 3: "c", 4: "d", 5: "e", 6: "f",
+        7: "g", 8: "i"
       ]
 
       """
@@ -64,7 +64,7 @@ final class DictionaryDeclTests: PrettyPrintTestCase {
       // dictionary.
       + """
       let a = [
-        10000: "abc", 20000: "def", 30000: "ghi",
+        10000: "abc", 20000: "def", 30000: "ghi"
       ]
 
       """
@@ -93,9 +93,9 @@ final class DictionaryDeclTests: PrettyPrintTestCase {
     let input =
       """
       let a = [
-        1: "a",
+        1: "a"
       ]
-      let a = [1: "a", 2: "b", 3: "c",]
+      let a = [1: "a", 2: "b", 3: "c"]
       let a: [Int: String] = [
         1: "a", 2: "b", 3: "c", 4: "d", 5: "e", 6: "f",
         7: "g", 8: "i"
@@ -104,23 +104,6 @@ final class DictionaryDeclTests: PrettyPrintTestCase {
 
     assertPrettyPrintEqual(
       input: input, expected: input + "\n", linelength: 50, whitespaceOnly: true)
-  }
-
-  func testTrailingCommaDiagnostics() {
-    let input =
-      """
-      let a = [1: "a", 2: "b", 3: "c",]
-      let a: [Int: String] = [
-        1: "a", 2: "b", 3: "c", 4: "d", 5: "e", 6: "f",
-        7: "g", 8: "i"
-      ]
-      """
-
-    assertPrettyPrintEqual(
-      input: input, expected: input + "\n", linelength: 50, whitespaceOnly: true)
-
-    XCTAssertDiagnosed(.removeTrailingComma, line: 1, column: 32)
-    XCTAssertDiagnosed(.addTrailingComma, line: 4, column: 17)
   }
 
   func testDiscretionaryNewlineAfterColon() {
@@ -186,7 +169,7 @@ final class DictionaryDeclTests: PrettyPrintTestCase {
       """
       let d = [
         key: cond ? firstOption : secondOption,
-        key2: bar(),
+        key2: bar()
       ]
       """
 
@@ -196,7 +179,7 @@ final class DictionaryDeclTests: PrettyPrintTestCase {
         key: cond
           ? firstOption
           : secondOption,
-        key2: bar(),
+        key2: bar()
       ]
 
       """
@@ -223,13 +206,13 @@ final class DictionaryDeclTests: PrettyPrintTestCase {
         key1: ("abc", "def", "xyz"),
         key2: (
           "this ", "string", "is long"
-        ),
+        )
       ]
       let a = [
         key1: ("abc", "def", "xyz"),
         key2: (
           "this ", "string", "is long"
-        ),
+        )
       ]
       let a = [
         key2: ("this ", "string", "is long")
@@ -243,11 +226,11 @@ final class DictionaryDeclTests: PrettyPrintTestCase {
         )
       ]
       let a = [
-        key1: ("a", "z"), key2: ("b ", "y"),
+        key1: ("a", "z"), key2: ("b ", "y")
       ]
       let a = [
         key1: ("ab", "z"),
-        key2: ("b ", "y"),
+        key2: ("b ", "y")
       ]
 
       """
@@ -257,7 +240,7 @@ final class DictionaryDeclTests: PrettyPrintTestCase {
       // dictionary.
       + """
       a = [
-        k1: ("ab", "z"), k2: ("bc", "y"),
+        k1: ("ab", "z"), k2: ("bc", "y")
       ]
 
       """

--- a/Tests/SwiftFormatPrettyPrintTests/FunctionCallTests.swift
+++ b/Tests/SwiftFormatPrettyPrintTests/FunctionCallTests.swift
@@ -155,11 +155,11 @@ final class FunctionCallTests: PrettyPrintTestCase {
       myFunc(someArray: [])
       myFunc(someArray: [
         1000, 2000, 3000, 4000, 5000, 6000, 7000,
-        8000,
+        8000
       ])
       myFunc(someDictionary: [:])
       myFunc(someDictionary: [
-        "foo": "bar", "baz": "quux", "gli": "glop",
+        "foo": "bar", "baz": "quux", "gli": "glop"
       ])
       myFunc(someClosure: {
       })
@@ -170,11 +170,11 @@ final class FunctionCallTests: PrettyPrintTestCase {
       })
       myFunc(someArray: [
         1000, 2000, 3000, 4000, 5000, 6000, 7000,
-        8000,
+        8000
       ]) { foo in bar() }
       myFunc(someArray: [
         1000, 2000, 3000, 4000, 5000, 6000, 7000,
-        8000,
+        8000
       ]) { foo in
         someMuchLongerLineBreakingBarFunction()
       }
@@ -198,22 +198,22 @@ final class FunctionCallTests: PrettyPrintTestCase {
       """
       myFunc([
         1000, 2000, 3000, 4000, 5000, 6000, 7000,
-        8000,
+        8000
       ])
       myFunc([
         "foo": "bar", "baz": "quux",
-        "glip": "glop",
+        "glip": "glop"
       ])
       myFunc({ foo, bar in
         baz(1000, 2000, 3000, 4000, 5000)
       })
       myFunc([
         1000, 2000, 3000, 4000, 5000, 6000, 7000,
-        8000,
+        8000
       ]) { foo in bar() }
       myFunc([
         1000, 2000, 3000, 4000, 5000, 6000, 7000,
-        8000,
+        8000
       ]) { foo in
         someMuchLongerLineBreakingBarFunction()
       }

--- a/Tests/SwiftFormatPrettyPrintTests/MemberAccessExprTests.swift
+++ b/Tests/SwiftFormatPrettyPrintTests/MemberAccessExprTests.swift
@@ -34,7 +34,7 @@ final class MemberAccessExprTests: PrettyPrintTestCase {
       let array = [
         .first,
         .second,
-        .third,
+        .third
       ]
 
       """
@@ -74,7 +74,7 @@ final class MemberAccessExprTests: PrettyPrintTestCase {
     let expectedNoForcedBreaks =
       """
       let result = [
-        1, 2, 3, 4, 5,
+        1, 2, 3, 4, 5
       ].filter {
         $0 % 2 == 0
       }.map { $0 * $0 }
@@ -97,7 +97,7 @@ final class MemberAccessExprTests: PrettyPrintTestCase {
     let expectedWithForcedBreaks =
       """
       let result = [
-        1, 2, 3, 4, 5,
+        1, 2, 3, 4, 5
       ]
       .filter {
         $0 % 2 == 0

--- a/Tests/SwiftFormatPrettyPrintTests/PrettyPrintTestCase.swift
+++ b/Tests/SwiftFormatPrettyPrintTests/PrettyPrintTestCase.swift
@@ -75,7 +75,8 @@ class PrettyPrintTestCase: DiagnosingTestCase {
       context: context,
       node: Syntax(sourceFileSyntax),
       printTokenStream: false,
-      whitespaceOnly: whitespaceOnly)
+      whitespaceOnly: whitespaceOnly,
+      shouldValidateTrailingComma: false)
     return printer.prettyPrint()
   }
 }

--- a/Tests/SwiftFormatPrettyPrintTests/SwitchStmtTests.swift
+++ b/Tests/SwiftFormatPrettyPrintTests/SwitchStmtTests.swift
@@ -139,7 +139,7 @@ final class SwitchStmtTests: PrettyPrintTestCase {
       case someVeryLongVarName,
         someOtherLongVarName:
         foo(a: [
-          1, 2, 3, 4, 5,
+          1, 2, 3, 4, 5
         ])
       default:
         print("default")


### PR DESCRIPTION
Fix: tests that use `,` at the end of arrays.
Fix: Add a mandatory new line between doc comments. Without this the parser won't find anything.